### PR TITLE
fixes in search box

### DIFF
--- a/src/js/main-page-searchByTitle.js
+++ b/src/js/main-page-searchByTitle.js
@@ -27,7 +27,13 @@ searchForm.addEventListener('submit', async event => {
 
   try {
     const header = { ...defaultHeaderGet, ...searchMovieUrl };
-    const parameters = { ...searchMovieParams, api_key: apikeyTMDB, query: searchQuery, page: 1 };
+    const parameters = {
+      ...searchMovieParams,
+      api_key: apikeyTMDB,
+      include_adult: false,
+      query: searchQuery,
+      page: 1,
+    };
     const serverData = await axiosGetData(header, parameters);
     const movies = serverData.data;
     // movies.page


### PR DESCRIPTION
Hej :) Wiem, że już pytałeś o to Julię - dodałam do search movie params paramet: include_adult: false, żeby odrzycał filmy "dla dorosłych", bo jak teraz miałam chwilkę i sprawdzenie jak działa stronka i wpisałam w search literę "f" to mi wyszukało bardzo dużo niepoprawnych treści ;) Ten parametr blokuje prawie wszystkie treści dla dorosłych. 